### PR TITLE
ci: Dependabot auto-merge pipeline + weekly scanning config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 10
+    reviewers:
+      - dobeutech
+    labels:
+      - dependencies
+      - automated
+    commit-message:
+      prefix: "deps:"
+      include: scope
+    groups:
+      patch-minor:
+        update-types:
+          - patch
+          - minor
+      major:
+        update-types:
+          - major
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - ci

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge-dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flag major updates for review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body "⚠️ **Major version bump detected** (${{ steps.metadata.outputs.dependency-names }} ${{ steps.metadata.outputs.previous-version }} → ${{ steps.metadata.outputs.new-version }}).\n\nThis PR requires manual review before merging. Please check the changelog for breaking changes.\n\n*Auto-flagged by DTS Dependabot pipeline*"
+          gh pr edit "$PR_URL" --add-label "needs-review"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Dependabot Auto-Merge Pipeline

Adds automated dependency management:

- **Auto-merge** patch/minor Dependabot PRs when CI passes
- **Flag** major version bumps with `needs-review` label
- **Weekly scanning** (Mondays 9AM ET) for npm + GitHub Actions deps
- **Grouped updates**: patch/minor batched, major separate

Resolves existing open Dependabot PR backlog.

**Linear:** [DTS-1164](https://linear.app/dobeutechsolutions/issue/DTS-1164)

---
*Deployed via Composio automation pipeline*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dobeutech/contentminer/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates Dependabot updates: auto-approves and auto-merges patch/minor PRs after checks pass, and flags majors for manual review. Adds weekly dependency scanning and grouped updates to keep noise low. Aligns with Linear DTS-1164.

- **New Features**
  - Auto-approve and enable auto-merge for patch/minor `dependabot[bot]` PRs via `gh` (merges after CI passes).
  - Comment and add `needs-review` label on major bumps.
  - Weekly scans (Mondays 9:00 AM ET) for `npm` and `github-actions`.
  - Grouped updates: batch patch/minor; majors opened separately.
  - Standardized Dependabot labels and commit prefix `deps:` with scope.

<sup>Written for commit 989fb6b945bdddef73936441f5191b10d772af09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

